### PR TITLE
feat(os-task): add `Eq` trait to `TaskStatus`

### DIFF
--- a/os/src/task/task.rs
+++ b/os/src/task/task.rs
@@ -8,9 +8,7 @@ pub struct TaskControlBlock {
     pub task_cx: TaskContext,
 }
 
-// see: https://github.com/rust-lang/rust-clippy/issues/9063
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum TaskStatus {
     UnInit,
     Ready,


### PR DESCRIPTION
For a simple enum like implementing the Copy trait.